### PR TITLE
migrate to GraphClient, add source_id filters to sharepoint search view

### DIFF
--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -145,6 +145,37 @@ class DRPSharepointSearchViewSet(SharePointSearchViewSet):
 
         return new_kwargs
 
+    def _apply_source_id_filters(self, qp):
+        source_id = qp.get("source_id")
+        if not source_id:
+            return
+        try:
+            source_obj = SourceId.objects.get(source_id=source_id)
+            default_filters = source_obj.default_filters or {}
+        except SourceId.DoesNotExist:
+            default_filters = {}
+        for key, value in default_filters.get("filters", {}).items():
+            if key not in qp:
+                qp[key] = value
+        search_kql = default_filters.get("search_kql", "")
+        if search_kql:
+            existing_search = qp.get("search", "")
+            if existing_search:
+                qp["search"] = f"({search_kql}) AND ({existing_search})"
+            else:
+                qp["search"] = search_kql
+        exclude_paths = default_filters.get("exclude_paths", [])
+        if exclude_paths:
+            path_exclusions = " ".join(f'-Path:"{p}"' for p in exclude_paths)
+            qp["search"] = f"{path_exclusions} {qp.get('search', '')}".strip()
+
+    def get_queryset(self, **kwargs):
+        qp = self.request.query_params.copy()
+        self._apply_source_id_filters(qp)
+        qp.update(kwargs)
+        kwargs = qp
+        return super().get_queryset(**kwargs)
+
     @action(detail=False, methods=["get"])
     def export(self, request, *args, **kwargs):
         exit_condition = True

--- a/src/donor_reporting_portal/apps/roles/tasks.py
+++ b/src/donor_reporting_portal/apps/roles/tasks.py
@@ -8,13 +8,9 @@ from django.utils.timezone import now
 from celery.utils.log import get_task_logger
 from dateutil.relativedelta import relativedelta
 from dateutil.utils import today
-from sharepoint_rest_api import config
-from sharepoint_rest_api.client import SharePointClient
-from sharepoint_rest_api.config import SHAREPOINT_PAGE_SIZE
-from sharepoint_rest_api.utils import to_camel
+from sharepoint_rest_api.graph_client import GraphClient
 from unicef_notification.utils import send_notification_with_template
 
-from donor_reporting_portal.api.serializers.fields import CTNSearchMultiSharePointField, CTNSearchSharePointField
 from donor_reporting_portal.api.serializers.sharepoint import (
     DRPSharePointSearchSerializer,
     GaviSharePointSearchSerializer,
@@ -28,10 +24,10 @@ logger = get_task_logger(__name__)
 
 class Notifier:
     donor_code = None
-    source_id = None
     serializer = None
     template_name = None
     group_name = None
+    page_size = 500
 
     def __init__(self, donor_code):
         self.donor = Donor.objects.get(code=donor_code)
@@ -54,19 +50,23 @@ class Notifier:
     def get_filter_dict(self, modified_date):
         return {}
 
-    def get_selected_fields(self):
+    def get_searchable_properties(self):
+        return set()
+
+    def get_reverse_map(self):
+        if self.serializer:
+            return self.serializer.get_property_name_reverse()
         return None
 
     def notify(self):
-        client = SharePointClient(
-            url=f"{config.SHAREPOINT_TENANT}/{config.SHAREPOINT_SITE_TYPE}/{config.SHAREPOINT_SITE}"
-        )
+        client = GraphClient()
 
         notification_periods = self.get_notify_periods()
 
         for period, modified_date, _ in notification_periods:
             filters = self.get_filter_dict(modified_date)
-            selected = self.get_selected_fields()
+            searchable_properties = self.get_searchable_properties()
+            reverse_map = self.get_reverse_map()
             page = 1
             exit_condition = True
             reports = []
@@ -76,12 +76,14 @@ class Notifier:
             if users:
                 while exit_condition:
                     response, total_rows = client.search(
+                        search=None,
                         filters=filters,
-                        select=selected,
-                        source_id=self.source_id,
                         page=page,
+                        searchable_properties=searchable_properties,
+                        reverse_map=reverse_map,
+                        page_size=self.page_size,
                     )
-                    exit_condition = page * SHAREPOINT_PAGE_SIZE < total_rows
+                    exit_condition = page * self.page_size < total_rows
                     page += 1
                     qs = self.serializer(response, many=True)
                     reports.extend(qs.data)
@@ -93,69 +95,64 @@ class Notifier:
 
 
 class DonorNotifier(Notifier):
-    source_id = settings.DRP_SOURCE_IDS["external"]
     serializer = DRPSharePointSearchSerializer
     template_name = "notify_donor"
 
+    document_type_filter = [
+        "Certified Financial Statement - EC",
+        "Certified Financial Statement - US Government",
+        "Certified Statement of Account",
+        "Certified Statement of Account EU",
+        "Certified Statement of Account JPO",
+        "Donor Statement CERF",
+        "Certified Financial Report - Final",
+        "Certified Financial Report - Interim",
+        "Donor Statement Innovation",
+        "Donor Statement Joint Programme",
+        "Donor Statement Joint Programme PUNO",
+        "Donor Statement JPO Summary",
+        "Donor Statement Trust Fund",
+        "Donor Statement UN",
+        "Donor Statement UNICEF Hosted Funds",
+        "FFR Form (SF-425)",
+        "JPO Expenditure Summary",
+        "Statement of Account Thematic Funds",
+        "Donor Statement by Activity",
+        "Interim Statement by Nature of expense",
+        "Funds Request Report",
+        "Non-Standard Statement",
+        "Emergency Consolidated - Final",
+        "Emergency  Consolidated - Interim",
+        "Thematic Emergency Global - Final",
+        "Thematic Emergency Global - Interim",
+        "Emergency - Two Pager",
+        "Emergency - Final",
+        "Emergency - Interim",
+        "Human Interest / Photos",
+        "Narrative - Final",
+        "Narrative - Interim",
+        "Narrative Consolidated - Final",
+        "Narrative Consolidated - Interim",
+        "Thematic Consolidated - Final",
+        "Thematic Consolidated - Interim",
+        "Thematic Global - Final",
+        "Thematic Global - Interim",
+        "Thematic - Final",
+        "Thematic - Interim",
+        "Short Summary Update",
+        "Official Receipts",
+        "Quarterly Monitoring Report",
+    ]
+
     def get_filter_dict(self, modified_date):
-        document_type_filter = [
-            "Certified Financial Statement - EC",
-            "Certified Financial Statement - US Government",
-            "Certified Statement of Account",
-            "Certified Statement of Account EU",
-            "Certified Statement of Account JPO",
-            "Donor Statement CERF",
-            "Certified Financial Report - Final",
-            "Certified Financial Report - Interim",
-            "Donor Statement Innovation",
-            "Donor Statement Joint Programme",
-            "Donor Statement Joint Programme PUNO",
-            "Donor Statement JPO Summary",
-            "Donor Statement Trust Fund",
-            "Donor Statement UN",
-            "Donor Statement UNICEF Hosted Funds",
-            "FFR Form (SF-425)",
-            "JPO Expenditure Summary",
-            "Statement of Account Thematic Funds",
-            "Donor Statement by Activity",
-            "Interim Statement by Nature of expense",
-            "Funds Request Report",
-            "Non-Standard Statement",
-            "Emergency Consolidated - Final",
-            "Emergency  Consolidated - Interim",
-            "Thematic Emergency Global - Final",
-            "Thematic Emergency Global - Interim",
-            "Emergency - Two Pager",
-            "Emergency - Final",
-            "Emergency - Interim",
-            "Human Interest / Photos",
-            "Narrative - Final",
-            "Narrative - Interim",
-            "Narrative Consolidated - Final",
-            "Narrative Consolidated - Interim",
-            "Thematic Consolidated - Final",
-            "Thematic Consolidated - Interim",
-            "Thematic Global - Final",
-            "Thematic Global - Interim",
-            "Thematic - Final",
-            "Thematic - Interim",
-            "Short Summary Update",
-            "Official Receipts",
-            "Quarterly Monitoring Report",
-        ]
         return {
-            "DRPDonorCode": self.donor.code,
-            "DRPDonorDocument": ",".join(document_type_filter),
-            "DRPModified__gte": modified_date.strftime("%Y-%m-%d"),
+            "Donor": self.donor.code,
+            "DonorDocument": ",".join(self.document_type_filter),
+            "Modified__gte": modified_date.strftime("%Y-%m-%d"),
         }
 
-    def get_selected_fields(self):
-        serializer_fields = DRPSharePointSearchSerializer._declared_fields.keys()
-        return ["DRP" + to_camel(x) for x in serializer_fields] + [
-            "Title",
-            "Author",
-            "Path",
-        ]
+    def get_searchable_properties(self):
+        return {"Donor", "DonorDocument", "Modified"}
 
     def get_queryset(self, period):
         return UserRole.objects.filter(donor=self.donor, notification_period=period).values(
@@ -164,7 +161,6 @@ class DonorNotifier(Notifier):
 
 
 class GaviNotifier(Notifier):
-    source_id = settings.DRP_SOURCE_IDS["gavi"]
     serializer = GaviSharePointSearchSerializer
     template_name = "notify_gavi"
 
@@ -181,19 +177,13 @@ class GaviNotifier(Notifier):
     def get_filter_dict(self, modified_date):
         date = self.specific_date or modified_date.strftime("%Y-%m-%d")
         return {
-            "DRPModified": date,
-            "CTNMOUReference": self.group_name,
-            "CTNUrgent__not": "Yes",
+            "Modified": date,
+            "MOUReference": self.group_name,
+            "Urgent__not": "Yes",
         }
 
-    def get_selected_fields(self):
-        def to_drp(source, value):
-            prefix = "CTN" if isinstance(value, CTNSearchSharePointField | CTNSearchMultiSharePointField) else "DRP"
-            return prefix + to_camel(source)
-
-        selected = [to_drp(key, value) for key, value in self.serializer._declared_fields.items()]
-        selected += ["Title", "Author", "Path"]
-        return selected
+    def get_searchable_properties(self):
+        return {"Modified", "MOUReference", "Urgent"}
 
 
 class GaviUrgentNotifier(GaviNotifier):
@@ -206,10 +196,13 @@ class GaviUrgentNotifier(GaviNotifier):
 
     def get_filter_dict(self, modified_date):
         return {
-            "DRPModified__gte": modified_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "CTNMOUReference": self.group_name,
-            "CTNUrgent": "Yes",
+            "Modified__gte": modified_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "MOUReference": self.group_name,
+            "Urgent": "Yes",
         }
+
+    def get_searchable_properties(self):
+        return {"Modified", "MOUReference", "Urgent"}
 
 
 @app.task

--- a/uv.lock
+++ b/uv.lock
@@ -2469,16 +2469,16 @@ wheels = [
 
 [[package]]
 name = "responses"
-version = "0.26.1"
+version = "0.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
 ]
 
 [[package]]
@@ -2530,16 +2530,16 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
 name = "sharepoint-rest-api"
-version = "0.21.3"
+version = "0.21.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -2549,9 +2549,9 @@ dependencies = [
     { name = "msal" },
     { name = "office365-rest-python-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/4f/17d80d09b8669851a77f65472a9df586f0b377fdfbeef702e215fd67ca00/sharepoint_rest_api-0.21.3.tar.gz", hash = "sha256:2088030c53f5feece3e4b48ff39d5b9e4142f3549d0c4a358cba157755d85c33", size = 19277, upload-time = "2026-07-03T16:15:49.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/23/4235626d772b03c487d74a01fe9bc583b81eb34e11032811a5c842e254a1/sharepoint_rest_api-0.21.4.tar.gz", hash = "sha256:d602ae1899434c4018b96aa633c90673f7ba6d869c3f4cd9b3470c994f429529", size = 19978, upload-time = "2026-07-06T13:15:11.771Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/80/66ff238f1c1648564582b241e14f85fce969fea95c1f91cddfe7f345e2cc/sharepoint_rest_api-0.21.3-py3-none-any.whl", hash = "sha256:c2b86fbef7d33b27458c22593273074832bf60aad1ac78f09cd8a05027a30e33", size = 29493, upload-time = "2026-07-03T16:15:48.421Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ad/92e78a225e4f03b01fa132c86fa539409e14c2ec49db5513a13c41fd85c6/sharepoint_rest_api-0.21.4-py3-none-any.whl", hash = "sha256:47f661b58bea88ae65b49fd66f0ef0403ee03033db864e1b8b8118b2048693e2", size = 30234, upload-time = "2026-07-06T13:15:10.682Z" },
 ]
 
 [[package]]
@@ -2937,15 +2937,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/9f/49/2f57640e889ba509f
 
 [[package]]
 name = "vcrpy"
-version = "8.2.1"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/db/08183b845b0040bb877dad2bd7e4e0976fc232bb3476d7ee369c6c4f8b5a/vcrpy-8.2.1.tar.gz", hash = "sha256:d73a6e4eb6dae8148e659764b7a00e68cc51ba29ba9e6a85e1f0790ad96b97df", size = 90511, upload-time = "2026-06-16T13:20:52.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/d5/8a1f8eb603e2d35fbb0ecd1e309d0c5c18a0ecfc8c0a8f04088bbc8f833b/vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212", size = 96117, upload-time = "2026-07-04T14:27:01.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/7c/0e812ab83f5289404c674f3461ba783250b967d34b5ab034d361236ec042/vcrpy-8.2.1-py3-none-any.whl", hash = "sha256:7ce58c9e2792b246f79d6f4b3e9660676cc6f853be17e1547305b4437ab1ff85", size = 44925, upload-time = "2026-06-16T13:20:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/34/77/cb4219be91508399cbcb6143bad89462cfb16f6c638458f454a5d46ac95a/vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9", size = 46530, upload-time = "2026-07-04T14:27:00.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate role notifier tasks from SharePointClient to GraphClient, adding property mapping support. Also add `_apply_source_id_filters` and override `get_queryset` in `DRPSharepointSearchViewSet` to apply source-level default filters.