### PR TITLE
fix: map serializer property names to managed names in tasks, fix Gav…

### DIFF
--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -214,6 +214,31 @@ class DRPSharePointUrlSearchViewSet(DRPViewSet, DRPSharepointSearchViewSet, Shar
     """DRP Search Viewset for url based."""
 
 
+PROPERTY_TO_MANAGED = {
+    "Donor": "Donor",
+    "GrantNumber": "RefinableString161",
+    "ReportGroup": "RefinableString164",
+    "ReportStatus": "RefinableString166",
+    "AwardType": "RefinableString176",
+    "Retracted": "RefinableString173",
+    "Created": "RefinableDate09",
+    "Modified": "RefinableDate11",
+    "GrantExpiryDate": "RefinableDate14",
+    "ReportEndDate": "RefinableDate15",
+    "DonorDocument": "RefinableString163",
+    "DonorReportCategory": "RefinableString171",
+    "ExternalReference": "RefinableString168",
+    "FrameworkAgreement": "RefinableString162",
+    "GrantIssueYear": "RefinableString167",
+    "RecipientOffice": "RefinableString165",
+    "ReportGeneratedBy": "RefinableString174",
+    "ReportMethod": "RefinableString172",
+    "ReportType": "RefinableString169",
+    "Theme": "RefinableString170",
+    "DonorCode": "RefinableString175",
+}
+
+
 class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
     """DRP Search Viewset for graph based.
 
@@ -224,29 +249,6 @@ class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
     """
 
     serializer_class = DRPSharePointSearchSerializer
-    _PROPERTY_TO_KQL = {
-        "Donor": "Donor",
-        "GrantNumber": "RefinableString161",
-        "ReportGroup": "RefinableString164",
-        "ReportStatus": "RefinableString166",
-        "AwardType": "RefinableString176",
-        "Retracted": "RefinableString173",
-        "Created": "RefinableDate09",
-        "Modified": "RefinableDate11",
-        "GrantExpiryDate": "RefinableDate14",
-        "ReportEndDate": "RefinableDate15",
-        "DonorDocument": "RefinableString163",
-        "DonorReportCategory": "RefinableString171",
-        "ExternalReference": "RefinableString168",
-        "FrameworkAgreement": "RefinableString162",
-        "GrantIssueYear": "RefinableString167",
-        "RecipientOffice": "RefinableString165",
-        "ReportGeneratedBy": "RefinableString174",
-        "ReportMethod": "RefinableString172",
-        "ReportType": "RefinableString169",
-        "Theme": "RefinableString170",
-        "DonorCode": "RefinableString175",
-    }
 
     def get_serializer_class(self):
         query_params = self.request.query_params
@@ -336,7 +338,7 @@ class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
             parts = name.split("__")
             raw = parts[0].lstrip("-")
             suffix = f"__{parts[-1]}" if len(parts) > 1 else ""
-            kql_name = self._PROPERTY_TO_KQL.get(raw, raw)
+            kql_name = PROPERTY_TO_MANAGED.get(raw, raw)
             if parts[0].startswith("-"):
                 converted[f"-{kql_name}{suffix}"] = value
             else:
@@ -346,7 +348,7 @@ class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
             search=search,
             filters=converted,
             page=page,
-            searchable_properties=set(self._PROPERTY_TO_KQL.values()),
+            searchable_properties=set(PROPERTY_TO_MANAGED.values()),
             reverse_map=reverse_map,
             order_by=order_by,
         )

--- a/src/donor_reporting_portal/apps/roles/tasks.py
+++ b/src/donor_reporting_portal/apps/roles/tasks.py
@@ -15,6 +15,7 @@ from donor_reporting_portal.api.serializers.sharepoint import (
     DRPSharePointSearchSerializer,
     GaviSharePointSearchSerializer,
 )
+from donor_reporting_portal.api.views.sharepoint import PROPERTY_TO_MANAGED
 from donor_reporting_portal.apps.report_metadata.models import Donor
 from donor_reporting_portal.apps.roles.models import UserRole
 from donor_reporting_portal.config.celery import app
@@ -58,14 +59,23 @@ class Notifier:
             return self.serializer.get_property_name_reverse()
         return None
 
+    @staticmethod
+    def _map_name_to_managed(name):
+        parts = name.split("__")
+        raw_name = parts[0].lstrip("-")
+        managed = PROPERTY_TO_MANAGED.get(raw_name, raw_name)
+        prefix = "-" if parts[0].startswith("-") else ""
+        suffix = f"__{parts[-1]}" if len(parts) > 1 else ""
+        return f"{prefix}{managed}{suffix}"
+
     def notify(self):
         client = GraphClient()
 
         notification_periods = self.get_notify_periods()
 
         for period, modified_date, _ in notification_periods:
-            filters = self.get_filter_dict(modified_date)
-            searchable_properties = self.get_searchable_properties()
+            filters = {self._map_name_to_managed(k): v for k, v in self.get_filter_dict(modified_date).items()}
+            searchable_properties = {PROPERTY_TO_MANAGED.get(p, p) for p in self.get_searchable_properties()}
             reverse_map = self.get_reverse_map()
             page = 1
             exit_condition = True
@@ -82,6 +92,7 @@ class Notifier:
                         searchable_properties=searchable_properties,
                         reverse_map=reverse_map,
                         page_size=self.page_size,
+                        order_by="DRPMODIFIED desc",
                     )
                     exit_condition = page * self.page_size < total_rows
                     page += 1
@@ -165,7 +176,7 @@ class GaviNotifier(Notifier):
     template_name = "notify_gavi"
 
     def __init__(self, donor_code, group_name, specific_date=None):
-        self.donor = Donor.objects.get(code=donor_code)
+        super().__init__(donor_code)
         self.group_name = group_name
         self.specific_date = specific_date
 
@@ -235,7 +246,7 @@ def notify_new_records():
     logger.info("Notify Start")
     for donor_code in Donor.objects.filter(active=True).values_list("code", flat=True):
         if donor_code == settings.GAVI_DONOR_CODE:
-            notify_gavi_donor(donor_code)
+            notify_gavi_donor.delay(donor_code)
         else:
             notify_donor.delay(donor_code)
 

--- a/tests/api/test_graph_search.py
+++ b/tests/api/test_graph_search.py
@@ -11,7 +11,7 @@ from donor_reporting_portal.api.serializers.sharepoint import (
     GaviSharePointSearchSerializer,
     GaviSoaSharePointSearchSerializer,
 )
-from donor_reporting_portal.api.views.sharepoint import DRPGraphBasedSearchViewSet
+from donor_reporting_portal.api.views.sharepoint import DRPGraphBasedSearchViewSet, PROPERTY_TO_MANAGED
 from sharepoint_rest_api.models import SourceId
 
 
@@ -201,7 +201,7 @@ class TestDRPGraphBasedSearchViewSet:
         assert call_kwargs["search"] is None
         assert call_kwargs["filters"] == {"Donor": "I49901"}
         assert call_kwargs["page"] == 1
-        assert call_kwargs["searchable_properties"] == set(DRPGraphBasedSearchViewSet._PROPERTY_TO_KQL.values())
+        assert call_kwargs["searchable_properties"] == set(PROPERTY_TO_MANAGED.values())
         assert result == []
 
     @override_settings(DRP_SOURCE_IDS={"internal": "test-uuid"})


### PR DESCRIPTION
…iNotifier init, fix notify_new_records async

- Extracted PROPERTY_TO_MANAGED to module level in sharepoint.py for reuse by both viewsets and tasks
- Added _map_name_to_managed() in Notifier to map filter names to actual SharePoint managed property names (e.g. Modified -> RefinableDate11, DonorDocument -> RefinableString163)
- Added order_by='DRPMODIFIED desc' to client.search() calls
- Fixed notify_new_records to use .delay() for GAVI (was calling synchronously)
- Fixed GaviNotifier.__init__ to call super().__init__ instead of duplicating Donor.objects.get()