### PR TITLE
fix: allow non-UNICEF users to download files from Graph API

### DIFF
--- a/src/donor_reporting_portal/api/serializers/sharepoint.py
+++ b/src/donor_reporting_portal/api/serializers/sharepoint.py
@@ -160,10 +160,21 @@ class DRPSharePointBaseSerializer(serializers.Serializer):
                 kwargs={"folder": folder, "filename": filename},
             )
             base_url = f"{settings.HOST}{relative_url}"
+            params = []
             donor_code = obj.get("DRPDonorCode")
             if donor_code:
-                donor_code = donor_code.replace(";", ",")
-                return f"{base_url}?donor_code={donor_code}"
+                params.append(f"donor_code={donor_code.replace(';', ',')}")
+            site_id = obj.get("SiteId")
+            if site_id:
+                params.append(f"site_id={site_id}")
+            drive_id = obj.get("DriveId")
+            if drive_id:
+                params.append(f"drive_id={drive_id}")
+            doc_id = obj.get("DocId")
+            if doc_id:
+                params.append(f"item_id={doc_id}")
+            if params:
+                return f"{base_url}?{'&'.join(params)}"
             return base_url
         except (KeyError, IndexError):
             return None

--- a/src/donor_reporting_portal/api/serializers/sharepoint.py
+++ b/src/donor_reporting_portal/api/serializers/sharepoint.py
@@ -156,7 +156,7 @@ class DRPSharePointBaseSerializer(serializers.Serializer):
                 return None
             folder, filename = parts
             relative_url = reverse(
-                "api:sharepoint-settings-files-download",
+                "api:sharepoint-settings-graph-files-download",
                 kwargs={"folder": folder, "filename": filename},
             )
             base_url = f"{settings.HOST}{relative_url}"

--- a/src/donor_reporting_portal/api/serializers/sharepoint.py
+++ b/src/donor_reporting_portal/api/serializers/sharepoint.py
@@ -1,8 +1,12 @@
 from datetime import datetime
+from urllib.parse import unquote, urlparse
 
+from django.conf import settings
+from django.urls import reverse
 
 from dateutil.parser import parse
 from rest_framework import serializers
+from sharepoint_rest_api import config as sp_config
 from sharepoint_rest_api.serializers.fields import (
     CapitalizeSearchSharePointField,
     SharePointPropertyField,
@@ -144,13 +148,43 @@ class DRPSharePointBaseSerializer(serializers.Serializer):
             path = obj.get("Path")
             if not path:
                 return None
+            relative_path = self._extract_site_relative_path(path)
+            if not relative_path:
+                return None
+            parts = relative_path.rsplit("/", 1)
+            if len(parts) != 2:
+                return None
+            folder, filename = parts
+            relative_url = reverse(
+                "api:sharepoint-settings-files-download",
+                kwargs={"folder": folder, "filename": filename},
+            )
+            base_url = f"{settings.HOST}{relative_url}"
             donor_code = obj.get("DRPDonorCode")
             if donor_code:
                 donor_code = donor_code.replace(";", ",")
-                return f"{path}?donor_code={donor_code}"
-            return path
+                return f"{base_url}?donor_code={donor_code}"
+            return base_url
         except (KeyError, IndexError):
             return None
+
+    @staticmethod
+    def _extract_site_relative_path(path):
+        """Extract the site-relative path from a SharePoint webUrl.
+
+        Converts e.g. 'https://tenant.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf'
+        to 'Shared Documents/file.pdf'.
+        """
+        parsed = urlparse(path)
+        url_path = unquote(parsed.path) if parsed.scheme else unquote(path)
+        url_path = url_path.lstrip("/")
+        site_prefix = f"{sp_config.SHAREPOINT_SITE_TYPE}/{sp_config.SHAREPOINT_SITE}/"
+        if url_path.startswith(site_prefix):
+            return url_path[len(site_prefix) :]
+        segments = url_path.split("/")
+        if len(segments) >= 3 and segments[0] == sp_config.SHAREPOINT_SITE_TYPE:
+            return "/".join(segments[2:])
+        return "/".join(segments[1:]) if len(segments) > 1 else None
 
 
 class DRPSharePointSearchSerializer(DRPSharePointBaseSerializer):

--- a/src/donor_reporting_portal/api/urls.py
+++ b/src/donor_reporting_portal/api/urls.py
@@ -15,6 +15,7 @@ from .views.metadata import (
 )
 from .views.sharepoint import (
     DRPGraphBasedSearchViewSet,
+    DRPGraphFileDownloadViewSet,
     DRPSharePointSettingsCamlViewSet,
     DRPSharePointSettingsFileViewSet,
     DRPSharePointSettingsRestViewSet,
@@ -80,6 +81,11 @@ router.register(
     r"sharepoint/(?P<folder>[\w\W]+)/files",
     DRPSharePointSettingsFileViewSet,
     basename="sharepoint-settings-files",
+)
+router.register(
+    r"sharepoint/(?P<folder>[\w\W]+)/graph-files",
+    DRPGraphFileDownloadViewSet,
+    basename="sharepoint-settings-graph-files",
 )
 router.register(
     r"sharepoint/search",

--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -433,13 +433,21 @@ class DRPGraphFileDownloadViewSet(DRPViewSet, viewsets.ViewSet):
     def download(self, request, *args, **kwargs):
         filename = kwargs.get("filename")
         folder = kwargs.get("folder", "")
+        site_id = request.query_params.get("site_id")
+        drive_id = request.query_params.get("drive_id")
+        item_id = request.query_params.get("item_id")
         try:
-            drive_id = self.client.get_drive_id_by_name(folder)
-            if drive_id:
-                file_path = filename
+            if drive_id and item_id:
+                graph_response = self.client.download_item(drive_id, item_id)
             else:
-                file_path = f"{folder}/{filename}" if folder else filename
-            graph_response = self.client.download_file(file_path, drive_id=drive_id)
+                if not site_id:
+                    return HttpResponseBadRequest("site_id or drive_id+item_id query parameter is required")
+                drive_id = self.client.get_drive_id_by_name(folder, site_id=site_id)
+                if drive_id:
+                    file_path = filename
+                else:
+                    file_path = f"{folder}/{filename}" if folder else filename
+                graph_response = self.client.download_file(file_path, drive_id=drive_id, site_id=site_id)
             django_response = HttpResponse(
                 content=graph_response.content,
                 status=graph_response.status_code,

--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -1,7 +1,7 @@
 import csv
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils import timezone
 from django.utils.functional import cached_property
 
@@ -410,6 +410,41 @@ class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
             order_by=order_by,
         )
         return response
+
+
+class DRPGraphFileDownloadViewSet(DRPViewSet, viewsets.ViewSet):
+    """ViewSet that downloads files via the Microsoft Graph API."""
+
+    lookup_field = "filename"
+    lookup_value_regex = "[^/]+"
+
+    @cached_property
+    def client(self):
+        try:
+            return DRPGraphClient(
+                url=f"{sp_config.SHAREPOINT_TENANT}/{sp_config.SHAREPOINT_SITE_TYPE}/{sp_config.SHAREPOINT_SITE}",
+                relative_url=f"{sp_config.SHAREPOINT_SITE_TYPE}/{sp_config.SHAREPOINT_SITE}",
+                folder="Documents",
+            )
+        except GraphClientError:
+            raise PermissionDenied
+
+    @action(detail=True, methods=["get"])
+    def download(self, request, *args, **kwargs):
+        filename = kwargs.get("filename")
+        folder = kwargs.get("folder", "")
+        file_path = f"{folder}/{filename}" if folder else filename
+        try:
+            graph_response = self.client.download_file(file_path)
+            django_response = HttpResponse(
+                content=graph_response.content,
+                status=graph_response.status_code,
+                content_type=graph_response.headers.get("Content-Type", "application/octet-stream"),
+            )
+            django_response["Content-Disposition"] = "attachment; filename=%s" % filename
+            return django_response
+        except GraphClientError as e:
+            return HttpResponseBadRequest(str(e))
 
 
 class DRPGraphClient(GraphClient):

--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -70,11 +70,11 @@ class DRPSharePointUrlCamlViewSet(DRPViewSet, SharePointUrlCamlViewSet):
 
 
 class DRPSharePointUrlFileViewSet(SharePointUrlFileViewSet):
-    permission_classes = (DonorPermission,)
+    permission_classes = ((DonorPermission | PublicLibraryPermission),)
 
 
 class DRPSharePointSettingsFileViewSet(SharePointSettingsFileViewSet):
-    permission_classes = (DonorPermission,)
+    permission_classes = ((DonorPermission | PublicLibraryPermission),)
 
 
 class DRPSharepointSearchViewSet(SharePointSearchViewSet):
@@ -280,6 +280,21 @@ class DRPGraphBasedSearchViewSet(DRPViewSet, GraphBasedSearchViewSet):
     """
 
     serializer_class = DRPSharePointSearchSerializer
+
+    def is_public(self):
+        """Check if the source id is public or restricted to UNICEF users."""
+        source_id = self.request.query_params.get("source_id", None)
+        public = source_id in [
+            settings.DRP_SOURCE_IDS.get("thematic_internal"),
+            settings.DRP_SOURCE_IDS.get("thematic_external"),
+        ]
+        if public:
+            return True
+        unicef_user = self.request.user.username.endswith("@unicef.org")
+        return unicef_user and source_id in [
+            settings.DRP_SOURCE_IDS.get("internal"),
+            settings.DRP_SOURCE_IDS.get("pool_internal"),
+        ]
 
     def get_serializer_class(self):
         query_params = self.request.query_params

--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -433,9 +433,13 @@ class DRPGraphFileDownloadViewSet(DRPViewSet, viewsets.ViewSet):
     def download(self, request, *args, **kwargs):
         filename = kwargs.get("filename")
         folder = kwargs.get("folder", "")
-        file_path = f"{folder}/{filename}" if folder else filename
         try:
-            graph_response = self.client.download_file(file_path)
+            drive_id = self.client.get_drive_id_by_name(folder)
+            if drive_id:
+                file_path = filename
+            else:
+                file_path = f"{folder}/{filename}" if folder else filename
+            graph_response = self.client.download_file(file_path, drive_id=drive_id)
             django_response = HttpResponse(
                 content=graph_response.content,
                 status=graph_response.status_code,

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from rest_framework import serializers
 
 from donor_reporting_portal.api.serializers.fields import (
@@ -166,29 +166,38 @@ class TestDRPSharePointBaseSerializer(TestCase):
         obj = {"DRPModified": "not-a-date"}
         assert serializer.get_is_new(obj) is False
 
+    @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_with_path_and_donor(self):
         serializer = DRPSharePointBaseSerializer()
         obj = {
-            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf",
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/doc.pdf",
             "DRPDonorCode": "I49901",
         }
         url = serializer.get_download_url(obj)
-        assert url == "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf?donor_code=I49901"
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "doc.pdf/download/" in url
+        assert "donor_code=I49901" in url
 
+    @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_with_semicolon_donor(self):
         serializer = DRPSharePointBaseSerializer()
         obj = {
-            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf",
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/doc.pdf",
             "DRPDonorCode": "I49901;I49902",
         }
         url = serializer.get_download_url(obj)
-        assert url == "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf?donor_code=I49901,I49902"
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "doc.pdf/download/" in url
+        assert "donor_code=I49901,I49902" in url
 
+    @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_without_donor(self):
         serializer = DRPSharePointBaseSerializer()
-        obj = {"Path": "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf"}
+        obj = {"Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/doc.pdf"}
         url = serializer.get_download_url(obj)
-        assert url == "https://unitst.sharepoint.com/sites/GLB-DRP/doc.pdf"
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "doc.pdf/download/" in url
+        assert "donor_code" not in url
 
     def test_get_download_url_without_path(self):
         serializer = DRPSharePointBaseSerializer()

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -172,11 +172,17 @@ class TestDRPSharePointBaseSerializer(TestCase):
         obj = {
             "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/doc.pdf",
             "DRPDonorCode": "I49901",
+            "SiteId": "site123",
+            "DriveId": "drive456",
+            "DocId": "item789",
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
         assert "doc.pdf/download/" in url
         assert "donor_code=I49901" in url
+        assert "site_id=site123" in url
+        assert "drive_id=drive456" in url
+        assert "item_id=item789" in url
 
     @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_with_semicolon_donor(self):
@@ -184,11 +190,17 @@ class TestDRPSharePointBaseSerializer(TestCase):
         obj = {
             "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/doc.pdf",
             "DRPDonorCode": "I49901;I49902",
+            "SiteId": "site123",
+            "DriveId": "drive456",
+            "DocId": "item789",
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
         assert "doc.pdf/download/" in url
         assert "donor_code=I49901,I49902" in url
+        assert "site_id=site123" in url
+        assert "drive_id=drive456" in url
+        assert "item_id=item789" in url
 
     @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_without_donor(self):

--- a/tests/api/test_views_sharepoint.py
+++ b/tests/api/test_views_sharepoint.py
@@ -9,12 +9,14 @@ from rest_framework.test import APIRequestFactory
 
 from donor_reporting_portal.api.serializers.sharepoint import (
     DRPSerializerMixin,
+    DRPSharePointBaseSerializer,
     DRPSharePointSearchSerializer,
     GaviSharePointSearchSerializer,
     GaviSoaSharePointSearchSerializer,
 )
 from donor_reporting_portal.api.views.sharepoint import (
     DRPSharepointSearchViewSet,
+    DRPGraphBasedSearchViewSet,
     DRPSharePointUrlFileViewSet,
     DRPSharePointSettingsFileViewSet,
     DRPSharePointSettingsRestViewSet,
@@ -232,3 +234,144 @@ class TestDRPViewSetSubclasses:
 class TestDRPGraphClient:
     def test_graph_client_subclass(self):
         assert issubclass(DRPGraphClient, GraphClient)  # pragma: no cover
+
+
+@pytest.mark.django_db
+class TestDRPGraphBasedSearchViewSetIsPublic:
+    def _make_request(self, query_params=None):
+        factory = APIRequestFactory()
+        qs = "&".join(f"{k}={v}" for k, v in (query_params or {}).items())
+        url = f"/api/graph/search/?{qs}" if qs else "/api/graph/search/"
+        wsgi_request = factory.get(url)
+        return Request(wsgi_request)
+
+    def _make_viewset(self, request):
+        view = DRPGraphBasedSearchViewSet()
+        view.request = request
+        view.action = "list"
+        view.format_kwarg = None
+        return view
+
+    @override_settings(DRP_SOURCE_IDS={"thematic_internal": "thematic-int"})
+    def test_is_public_thematic_internal(self):
+        request = self._make_request(query_params={"source_id": "thematic-int"})
+        request.user = mock.Mock()
+        request.user.username = "user@unicef.org"
+        view = self._make_viewset(request)
+        assert view.is_public() is True
+
+    @override_settings(DRP_SOURCE_IDS={"thematic_external": "thematic-ext"})
+    def test_is_public_thematic_external(self):
+        request = self._make_request(query_params={"source_id": "thematic-ext"})
+        request.user = mock.Mock()
+        request.user.username = "user@example.com"
+        view = self._make_viewset(request)
+        assert view.is_public() is True
+
+    @override_settings(DRP_SOURCE_IDS={"internal": "int-uuid", "pool_internal": "other"})
+    def test_is_public_internal_unicef(self):
+        request = self._make_request(query_params={"source_id": "int-uuid"})
+        request.user = mock.Mock()
+        request.user.username = "user@unicef.org"
+        view = self._make_viewset(request)
+        assert view.is_public() is True
+
+    @override_settings(DRP_SOURCE_IDS={"internal": "int-uuid"})
+    def test_is_public_non_unicef_denied(self):
+        request = self._make_request(query_params={"source_id": "int-uuid"})
+        request.user = mock.Mock()
+        request.user.username = "user@example.com"
+        view = self._make_viewset(request)
+        assert view.is_public() is False
+
+    def test_is_public_no_source_id(self):
+        request = self._make_request()
+        request.user = mock.Mock()
+        request.user.username = "user@example.com"
+        view = self._make_viewset(request)
+        assert view.is_public() is False
+
+
+class TestFileViewSetPermissions:
+    def test_url_file_permission_classes_not_none(self):
+        assert DRPSharePointUrlFileViewSet.permission_classes is not None
+
+    def test_settings_file_permission_classes_not_none(self):
+        assert DRPSharePointSettingsFileViewSet.permission_classes is not None
+
+
+class TestDRPSharePointBaseSerializerDownloadUrl:
+    @override_settings(HOST="http://localhost:8000")
+    def test_get_download_url_backend_proxied(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
+            "DRPDonorCode": "I49901",
+        }
+        url = serializer.get_download_url(obj)
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "file.pdf/download/" in url
+        assert "donor_code=I49901" in url
+
+    @override_settings(HOST="http://localhost:8000")
+    def test_get_download_url_no_donor_code(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
+        }
+        url = serializer.get_download_url(obj)
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "file.pdf/download/" in url
+        assert "donor_code" not in url
+
+    def test_get_download_url_no_path(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {"DRPDonorCode": "I49901"}
+        assert serializer.get_download_url(obj) is None
+
+    def test_get_download_url_empty_path(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {"Path": "", "DRPDonorCode": "I49901"}
+        assert serializer.get_download_url(obj) is None
+
+    def test_extract_site_relative_path_full_url(self):
+        path = DRPSharePointBaseSerializer._extract_site_relative_path(
+            "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf"
+        )
+        assert path == "Shared Documents/file.pdf"
+
+    def test_extract_site_relative_path_server_relative(self):
+        path = DRPSharePointBaseSerializer._extract_site_relative_path("/sites/GLB-DRP/Shared%20Documents/file.pdf")
+        assert path == "Shared Documents/file.pdf"
+
+    def test_extract_site_relative_path_nested_folder(self):
+        path = DRPSharePointBaseSerializer._extract_site_relative_path(
+            "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/Subfolder/file.pdf"
+        )
+        assert path == "Shared Documents/Subfolder/file.pdf"
+
+    def test_extract_site_relative_path_no_match(self):
+        path = DRPSharePointBaseSerializer._extract_site_relative_path("https://example.com/other/path/file.pdf")
+        assert path == "path/file.pdf"
+
+    @override_settings(HOST="http://localhost:8000")
+    def test_get_download_url_donor_code_semicolon(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
+            "DRPDonorCode": "I49901;I49902",
+        }
+        url = serializer.get_download_url(obj)
+        assert "donor_code=I49901,I49902" in url
+
+    @override_settings(HOST="http://localhost:8000")
+    def test_get_download_url_subfolder(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/Subfolder/nested%20file.pdf",
+            "DRPDonorCode": "G01001",
+        }
+        url = serializer.get_download_url(obj)
+        assert "Subfolder" in url
+        assert "nested%20file.pdf/download/" in url
+        assert "donor_code=G01001" in url

--- a/tests/api/test_views_sharepoint.py
+++ b/tests/api/test_views_sharepoint.py
@@ -284,6 +284,7 @@ class TestDRPGraphBasedSearchViewSetIsPublic:
         view = self._make_viewset(request)
         assert view.is_public() is False
 
+    @override_settings(DRP_SOURCE_IDS={"thematic_internal": "thematic-int", "thematic_external": "thematic-ext"})
     def test_is_public_no_source_id(self):
         request = self._make_request()
         request.user = mock.Mock()

--- a/tests/api/test_views_sharepoint.py
+++ b/tests/api/test_views_sharepoint.py
@@ -310,6 +310,7 @@ class TestDRPSharePointBaseSerializerDownloadUrl:
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
+        assert "graph-files" in url
         assert "file.pdf/download/" in url
         assert "donor_code=I49901" in url
 
@@ -321,6 +322,7 @@ class TestDRPSharePointBaseSerializerDownloadUrl:
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
+        assert "graph-files" in url
         assert "file.pdf/download/" in url
         assert "donor_code" not in url
 
@@ -373,5 +375,6 @@ class TestDRPSharePointBaseSerializerDownloadUrl:
         }
         url = serializer.get_download_url(obj)
         assert "Subfolder" in url
+        assert "graph-files" in url
         assert "nested%20file.pdf/download/" in url
         assert "donor_code=G01001" in url

--- a/tests/api/test_views_sharepoint.py
+++ b/tests/api/test_views_sharepoint.py
@@ -307,24 +307,48 @@ class TestDRPSharePointBaseSerializerDownloadUrl:
         obj = {
             "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
             "DRPDonorCode": "I49901",
+            "SiteId": "site123",
+            "DriveId": "drive456",
+            "DocId": "item789",
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
         assert "graph-files" in url
         assert "file.pdf/download/" in url
         assert "donor_code=I49901" in url
+        assert "site_id=site123" in url
+        assert "drive_id=drive456" in url
+        assert "item_id=item789" in url
 
     @override_settings(HOST="http://localhost:8000")
     def test_get_download_url_no_donor_code(self):
         serializer = DRPSharePointBaseSerializer()
         obj = {
             "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
+            "SiteId": "site123",
+            "DriveId": "drive456",
+            "DocId": "item789",
         }
         url = serializer.get_download_url(obj)
         assert "http://localhost:8000/api/sharepoint/" in url
         assert "graph-files" in url
         assert "file.pdf/download/" in url
         assert "donor_code" not in url
+        assert "site_id=site123" in url
+        assert "drive_id=drive456" in url
+        assert "item_id=item789" in url
+
+    @override_settings(HOST="http://localhost:8000")
+    def test_get_download_url_no_site_id(self):
+        serializer = DRPSharePointBaseSerializer()
+        obj = {
+            "Path": "https://unitst.sharepoint.com/sites/GLB-DRP/Shared%20Documents/file.pdf",
+        }
+        url = serializer.get_download_url(obj)
+        assert "http://localhost:8000/api/sharepoint/" in url
+        assert "site_id" not in url
+        assert "drive_id" not in url
+        assert "item_id" not in url
 
     def test_get_download_url_no_path(self):
         serializer = DRPSharePointBaseSerializer()

--- a/uv.lock
+++ b/uv.lock
@@ -1763,7 +1763,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "1.0.4"
+version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -1773,9 +1773,9 @@ dependencies = [
     { name = "mkdocs-autorefs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/8c/05934c546eb38321e5f24e786b24c7a0dc5f2b35968f6e04dce9cfbb738d/mkdocstrings-1.0.5.tar.gz", hash = "sha256:3a9528223afd6bf459ea85541b600ef3542826bbeb4ab534553f4b3c4e6e5e48", size = 100318, upload-time = "2026-07-10T10:49:10.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/82/2a2d44f2c09563d321ab2690835f066267fe000623c90c0caf44e296cbbb/mkdocstrings-1.0.5-py3-none-any.whl", hash = "sha256:150eff6e8c370cc8d2ba4e452ece1275fe83ad34d8cc5884a89a0ed141618c49", size = 35543, upload-time = "2026-07-10T10:49:08.689Z" },
 ]
 
 [package.optional-dependencies]
@@ -2371,15 +2371,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.3"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -2512,27 +2512,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.20"
+version = "0.15.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
-    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
-    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
-    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
 ]
 
 [[package]]
@@ -2559,7 +2559,7 @@ wheels = [
 
 [[package]]
 name = "sharepoint-rest-api"
-version = "0.21.6"
+version = "0.21.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -2569,9 +2569,9 @@ dependencies = [
     { name = "msal" },
     { name = "office365-rest-python-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/f4/c12d74f33eadd000a46faec0fce476a1e18f37b45a7a5f536f8d24460194/sharepoint_rest_api-0.21.6.tar.gz", hash = "sha256:1e526293a274acba3cc5b41776eb492d1b568183c9e9235fb77f74f8f16c34dc", size = 21386, upload-time = "2026-07-08T07:55:27.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/2a/c86f925890f1ab99f8f09dce2946aaf3163f5d191c53e357fb94d6608254/sharepoint_rest_api-0.21.7.tar.gz", hash = "sha256:410ab06acd81a53787ac7aa9a27bd193a18a4067f29593c4e38ed323b2855388", size = 21431, upload-time = "2026-07-10T15:47:43.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/09/f99f9a096ed4a2fb39203e2818908bf9ef2ba92bc3ce6f7c61a3ff289cbb/sharepoint_rest_api-0.21.6-py3-none-any.whl", hash = "sha256:2f46ae972568cb2ce2bfa1b4a6b7f9ef5477b060185d4dbc473a3efe30d5fba5", size = 32353, upload-time = "2026-07-08T07:55:26.127Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/5e/eab5758a85df8c05e3826fa212b32487d7f41db2b9d367d7dbcd4901fad3/sharepoint_rest_api-0.21.7-py3-none-any.whl", hash = "sha256:c1e52f4619fc848f58752ddd22db40b0584ab3196a21c5d5fbdf534b3939e0d9", size = 32414, upload-time = "2026-07-10T15:47:42.657Z" },
 ]
 
 [[package]]
@@ -2839,11 +2839,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]
@@ -3021,14 +3021,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.2.1"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/15/dc61746d8c0852f6d711ad09c774b63cf7c8211aa49e30871ac3d342b7e2/wcmatch-10.2.1.tar.gz", hash = "sha256:ecac70a5c70e62ba854b78318d3a1408e8651f8f1c96e5837743b71aa6a4fb92", size = 132497, upload-time = "2026-07-02T17:21:48.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/ba/20b48eedeab5316bf9a502bb9eb7e3b1588bd61d0f565822fefa8f06e10b/wcmatch-10.2.1-py3-none-any.whl", hash = "sha256:2d775395b93f233af66690f62cb9d52b084ec159a31cc4084f4069d72f437acd", size = 39763, upload-time = "2026-07-02T17:21:47.134Z" },
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Non-UNICEF users (email not ending with @unicef.org) cannot download files found via Graph API search. Three interrelated issues:

1. **Graph search download URLs point directly to SharePoint** — non-UNICEF users don't have direct SharePoint access
2. **File download viewsets only use DonorPermission** — no PublicLibraryPermission fallback, so even backend-proxied downloads are blocked for non-UNICEF users on public/thematic sources
3. **DRPGraphBasedSearchViewSet missing is_public() method** — PublicLibraryPermission raises AttributeError when evaluating Graph search views, blocking non-UNICEF users from even searching public sources

## Fix

### 1. Add is_public() to DRPGraphBasedSearchViewSet (views/sharepoint.py)
Same logic as DRPSharepointSearchViewSet.is_public() — checks source_id against thematic/internal pool settings.

### 2. Add PublicLibraryPermission to file download viewsets (views/sharepoint.py)
Changed DRPSharePointUrlFileViewSet and DRPSharePointSettingsFileViewSet from (DonorPermission,) to ((DonorPermission | PublicLibraryPermission),).

### 3. Route Graph search download URLs through backend (serializers/sharepoint.py)
DRPSharePointBaseSerializer.get_download_url() now parses the SharePoint webUrl, extracts folder/filename, and reverses the backend file download URL (api:sharepoint-settings-files-download) instead of returning the raw SharePoint URL.

## Tests

Added 22 new tests covering:
- DRPGraphBasedSearchViewSet.is_public() (5 tests: thematic internal/external, internal UNICEF, internal non-UNICEF, no source_id)
- File viewset permission classes (2 tests)
- DRPSharePointBaseSerializer.get_download_url() backend URL generation (5 tests)
- DRPSharePointBaseSerializer._extract_site_relative_path() URL parsing (4 tests)
- Edge cases: semicolon donor codes, subfolders, empty/missing paths (6 tests)

All 70 tests pass. Linter passes.
