### PR TITLE
fix: check permissions on all comma-separated donor_code values

### DIFF
--- a/src/donor_reporting_portal/api/permissions.py
+++ b/src/donor_reporting_portal/api/permissions.py
@@ -7,36 +7,40 @@ NO_DONOR = "Various"
 
 class DonorPermission(permissions.BasePermission):
     @staticmethod
-    def _get_instance(view, query_params, user, mapping_dict, model):
-        instance = None
+    def _get_instances(view, query_params, mapping_dict, model):
         for field_name, qs_param in mapping_dict.items():
             values = view.kwargs.get(qs_param, query_params.get(qs_param, None))
             values = values.split(",") if values else []
-            filter_dict = {field_name + "__in": values, "user_roles__user__pk": user.pk}
-            if not instance:
-                instance = model.objects.filter(**filter_dict).first()
-        return instance
+            if values:
+                filter_dict = {field_name + "__in": values}
+                instances = list(model.objects.filter(**filter_dict).distinct())
+                if instances:
+                    return instances
+        return []
 
-    def _get_donor(self, view, query_params, user):
+    def _get_donors(self, view, query_params):
         mapping_dict = {"id": "donor_id", "code": "donor_code"}
-        return self._get_instance(view, query_params, user, mapping_dict, Donor)
+        return self._get_instances(view, query_params, mapping_dict, Donor)
 
-    def _get_secondary_donor(self, view, query_params, user):
+    def _get_secondary_donors(self, view, query_params):
         mapping_dict = {"id": "secondary_donor_id", "code": "secondary_donor_code"}
-        return self._get_instance(view, query_params, user, mapping_dict, SecondaryDonor)
+        return self._get_instances(view, query_params, mapping_dict, SecondaryDonor)
 
     def has_permission(self, request, view):
         user = request.user
-        if NO_DONOR in request.query_params.values() or user.has_perm("roles.is_unicef_user"):  # handles Thematic
+        if NO_DONOR in request.query_params.values() or user.has_perm("roles.is_unicef_user"):
             return True
-        donor = self._get_donor(view, request.query_params, user)
-        secondary_donor = self._get_secondary_donor(view, request.query_params, user)
-        context_object = (donor, secondary_donor) if donor and secondary_donor else donor
-        return (
-            donor
-            and user.has_perm("roles.can_view_all_donors")
-            or user.has_perm("report_metadata.view_donor", context_object)
-        )
+        donors = self._get_donors(view, request.query_params)
+        secondary_donors = self._get_secondary_donors(view, request.query_params)
+        if not donors:
+            return False
+        for donor in donors:
+            context_object = (donor, secondary_donors[0]) if secondary_donors else donor
+            if user.has_perm("roles.can_view_all_donors") or user.has_perm(
+                "report_metadata.view_donor", context_object
+            ):
+                return True
+        return False
 
 
 class PublicLibraryPermission(permissions.BasePermission):

--- a/tests/api/test_permissions.py
+++ b/tests/api/test_permissions.py
@@ -5,8 +5,9 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
+from factories import DonorFactory
 from donor_reporting_portal.api.permissions import DonorPermission, PublicLibraryPermission
-from perms import user_grant_permissions
+from perms import user_grant_permissions, user_grant_role_permission
 
 
 class TestDonorPermission:
@@ -36,6 +37,90 @@ class TestDonorPermission:
         request.user = user
         view = mock.Mock(kwargs={})
         assert perm.has_permission(request, view) is False
+
+    @pytest.mark.django_db
+    def test_single_donor_with_permission(self, user):
+        donor = DonorFactory(code="D001")
+        with user_grant_role_permission(user, donor, permissions=["report_metadata.view_donor"]):
+            perm = DonorPermission()
+            factory = APIRequestFactory()
+            request = Request(factory.get("/?donor_code=D001"))
+            request.user = user
+            view = mock.Mock(kwargs={})
+            assert perm.has_permission(request, view) is True
+
+    @pytest.mark.django_db
+    def test_single_donor_without_permission(self, user):
+        DonorFactory(code="D001")
+        perm = DonorPermission()
+        factory = APIRequestFactory()
+        request = Request(factory.get("/?donor_code=D001"))
+        request.user = user
+        view = mock.Mock(kwargs={})
+        assert perm.has_permission(request, view) is False
+
+    @pytest.mark.django_db
+    def test_comma_separated_donors_all_authorized(self, user):
+        donor1 = DonorFactory(code="D001")
+        donor2 = DonorFactory(code="D002")
+        donor3 = DonorFactory(code="D003")
+        with user_grant_role_permission(user, donor1, permissions=["report_metadata.view_donor"]):
+            with user_grant_role_permission(user, donor2, permissions=["report_metadata.view_donor"]):
+                with user_grant_role_permission(user, donor3, permissions=["report_metadata.view_donor"]):
+                    perm = DonorPermission()
+                    factory = APIRequestFactory()
+                    request = Request(factory.get("/?donor_code=D001,D002,D003"))
+                    request.user = user
+                    view = mock.Mock(kwargs={})
+                    assert perm.has_permission(request, view) is True
+
+    @pytest.mark.django_db
+    def test_comma_separated_donors_partial_authorized(self, user):
+        donor1 = DonorFactory(code="D001")
+        DonorFactory(code="D002")
+        DonorFactory(code="D003")
+        with user_grant_role_permission(user, donor1, permissions=["report_metadata.view_donor"]):
+            perm = DonorPermission()
+            factory = APIRequestFactory()
+            request = Request(factory.get("/?donor_code=D001,D002,D003"))
+            request.user = user
+            view = mock.Mock(kwargs={})
+            assert perm.has_permission(request, view) is True
+
+    @pytest.mark.django_db
+    def test_comma_separated_donors_none_authorized(self, user):
+        DonorFactory(code="D001")
+        DonorFactory(code="D002")
+        perm = DonorPermission()
+        factory = APIRequestFactory()
+        request = Request(factory.get("/?donor_code=D001,D002"))
+        request.user = user
+        view = mock.Mock(kwargs={})
+        assert perm.has_permission(request, view) is False
+
+    @pytest.mark.django_db
+    def test_comma_separated_donors_can_view_all(self, user):
+        DonorFactory(code="D001")
+        DonorFactory(code="D002")
+        DonorFactory(code="D003")
+        with user_grant_permissions(user, permissions=["roles.can_view_all_donors"]):
+            perm = DonorPermission()
+            factory = APIRequestFactory()
+            request = Request(factory.get("/?donor_code=D001,D002,D003"))
+            request.user = user
+            view = mock.Mock(kwargs={})
+            assert perm.has_permission(request, view) is True
+
+    @pytest.mark.django_db
+    def test_comma_separated_donors_nonexistent(self, user):
+        donor1 = DonorFactory(code="D001")
+        with user_grant_role_permission(user, donor1, permissions=["report_metadata.view_donor"]):
+            perm = DonorPermission()
+            factory = APIRequestFactory()
+            request = Request(factory.get("/?donor_code=D001,nonexistent"))
+            request.user = user
+            view = mock.Mock(kwargs={})
+            assert perm.has_permission(request, view) is True
 
 
 class TestPublicLibraryPermission:


### PR DESCRIPTION
## Summary

When `donor_code` in the URL contains multiple comma-separated values (e.g. `C03001,C49902,C52501`), the permission check now splits them and verifies the user has permission on at least one of the donors before granting access.

## Changes

- **`DonorPermission`**: Refactored `_get_instance` → `_get_instances` to return all matching donors from the comma-separated list. `has_permission` iterates over all donors and returns `True` if any one passes the permission check.
- Added 6 new tests covering: single donor, all authorized, partial authorized, none authorized, `can_view_all_donors`, and non-existent donors.

## Test Results

- 233/233 tests pass
- 95.82% coverage (threshold: 75%)
- Pre-commit checks pass