### PR TITLE
Require donor_code for file download endpoint

### DIFF
--- a/src/donor_reporting_portal/api/views/sharepoint.py
+++ b/src/donor_reporting_portal/api/views/sharepoint.py
@@ -385,6 +385,9 @@ class DRPGraphFileDownloadViewSet(DRPViewSet, GraphFileDownloadViewSet):
 
     @action(detail=True, methods=["get"])
     def download(self, request, *args, **kwargs):
+        donor_code = request.query_params.get("donor_code")
+        if not donor_code:
+            raise PermissionDenied("donor_code is required")
         filename = kwargs.get("filename")
         folder = kwargs.get("folder", "")
         site_id = request.query_params.get("site_id")

--- a/tests/api/test_views_sharepoint.py
+++ b/tests/api/test_views_sharepoint.py
@@ -4,6 +4,7 @@ from unittest import mock
 from django.test import override_settings
 
 import pytest
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
@@ -17,6 +18,7 @@ from donor_reporting_portal.api.serializers.sharepoint import (
 from donor_reporting_portal.api.views.sharepoint import (
     DRPSharepointSearchViewSet,
     DRPGraphBasedSearchViewSet,
+    DRPGraphFileDownloadViewSet,
     SharePointGroupViewSet,
     DRPGraphClient,
 )
@@ -357,3 +359,50 @@ class TestDRPSharePointBaseSerializerDownloadUrl:
         assert "/api/graph/" in url
         assert "nested%20file.pdf/download/" in url
         assert "donor_code=G01001" in url
+
+
+class TestDRPGraphFileDownloadViewSet:
+    def _make_request(self, query_params=None):
+        factory = APIRequestFactory()
+        qs = "&".join(f"{k}={v}" for k, v in (query_params or {}).items())
+        url = (
+            f"/api/graph/Documents/files/test.pdf/download/?{qs}"
+            if qs
+            else "/api/graph/Documents/files/test.pdf/download/"
+        )
+        wsgi_request = factory.get(url)
+        return Request(wsgi_request)
+
+    def _make_viewset(self, request):
+        view = DRPGraphFileDownloadViewSet()
+        view.request = request
+        view.action = "download"
+        view.format_kwarg = None
+        view.kwargs = {"folder": "Documents", "filename": "test.pdf"}
+        return view
+
+    def test_download_no_donor_code_denied(self):
+        request = self._make_request(query_params={"site_id": "site123"})
+        view = self._make_viewset(request)
+        with pytest.raises(PermissionDenied, match="donor_code is required"):
+            view.download(request, folder="Documents", filename="test.pdf")
+
+    def test_download_donor_code_various_allowed(self):
+        request = self._make_request(query_params={"donor_code": "Various", "site_id": "site123"})
+        view = self._make_viewset(request)
+        with mock.patch.object(view, "client") as mock_client:
+            mock_client.download_file.return_value = mock.Mock(
+                content=b"file", status_code=200, headers={"Content-Type": "application/pdf"}
+            )
+            response = view.download(request, folder="Documents", filename="test.pdf")
+            assert response.status_code == 200
+
+    def test_download_donor_code_present_allowed(self):
+        request = self._make_request(query_params={"donor_code": "D001", "site_id": "site123"})
+        view = self._make_viewset(request)
+        with mock.patch.object(view, "client") as mock_client:
+            mock_client.download_file.return_value = mock.Mock(
+                content=b"file", status_code=200, headers={"Content-Type": "application/pdf"}
+            )
+            response = view.download(request, folder="Documents", filename="test.pdf")
+            assert response.status_code == 200


### PR DESCRIPTION
## Summary

Add a guard in `DRPGraphFileDownloadViewSet.download` that raises `PermissionDenied("donor_code is required")` when the `donor_code` query parameter is missing.

## Why

Without this check, the file download endpoint can be hit without a valid `donor_code`, meaning the `DonorPermission` check doesn't validate donor-level access. This allows potential URL manipulation where a user copies a download URL and replaces the `donor_code` with their own.

## Changes

- **`src/donor_reporting_portal/api/views/sharepoint.py`**: Added early `PermissionDenied` check at the top of `DRPGraphFileDownloadViewSet.download`
- **`tests/api/test_views_sharepoint.py`**: Added 3 tests covering the new guard (missing donor_code, Various, valid donor_code)

## Behavior

| Scenario | Result |
|---|---|
| No `donor_code` param | 403 PermissionDenied |
| `donor_code=Various` | Passes guard, `DonorPermission` handles access |
| `donor_code=D001` (valid) | Passes guard, `DonorPermission` validates access |
| `PublicLibraryPermission` | Unaffected (OR in `permission_classes`) |
